### PR TITLE
Fallback to superclass in OpenBSD::getCompilerRT for missing libs

### DIFF
--- a/clang/lib/Driver/ToolChains/OpenBSD.cpp
+++ b/clang/lib/Driver/ToolChains/OpenBSD.cpp
@@ -16,6 +16,7 @@
 #include "clang/Driver/SanitizerArgs.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/VirtualFileSystem.h"
 
 using namespace clang::driver;
 using namespace clang::driver::tools;
@@ -309,7 +310,9 @@ std::string OpenBSD::getCompilerRT(const ArgList &Args,
     std::string CRTBasename =
         getCompilerRTBasename(Args, Component, Type, /*AddArch=*/false);
     llvm::sys::path::append(P, "lib", CRTBasename);
-    return std::string(P.str());
+    if (getVFS().exists(P))
+      return std::string(P.str());
+    return ToolChain::getCompilerRT(Args, Component, Type);
   }
 }
 


### PR DESCRIPTION
This helps with running tests from llvm development tree which doesn't
have the libraries in OpenBSD preferred installed location.

Tested with gmake check-asan that previous failed to find clangrt libraries.